### PR TITLE
feat: remove working_directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
   node-base: &node-base
     docker:
       - image: node
-    working_directory: ~/working_directory
     steps:
       - run:
           name: Versions


### PR DESCRIPTION
> `working_directory` is no longer required, defaults to `~/project/` - CircleCI 2.0 - CircleCI Community Discussion
> https://discuss.circleci.com/t/working-directory-is-no-longer-required-defaults-to-project/14363