### PR TITLE
Use circleci/node orb executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - run: npm version
       - checkout
-      - node/install-packages
+      - node/install-packages:
+          # Cache is broken: https://github.com/CircleCI-Public/node-orb/issues/35
+          with-cache: false
       - run: npm test
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,4 +23,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              node-version: ["10.20.1", "12.16.3", "14.2.0"]
+              node-version: ["10.20", "12.16", "14.2"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,4 +23,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              node-version: ["10.20", "12.16", "14.2"]
+              node-version: ["10.20", "12.16", "14.2", "lts", "current", "latest"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,28 +3,19 @@ version: 2.1
 orbs:
   node: circleci/node@2.1
 
-executors:
-  linux:
-    docker:
-      - image: cimg/base:stable
-  macos:
-    macos:
-      xcode: 11.4
-
 jobs:
   test:
     parameters:
-      os:
-        type: executor
       node-version:
         type: string
-    executor: << parameters.os >>
+    executor:
+      name: node/default
+      tag: << parameters.node-version >>
     steps:
+      - run: npm version
       - checkout
-      - node/install:
-          node-version: << parameters.node-version >>
       - node/install-packages
-      - run: npm run test
+      - run: npm test
 
 workflows:
   matrix-tests:
@@ -32,5 +23,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [linux]
               node-version: ["10.20.1", "12.16.3", "14.2.0"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,4 +23,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              node-version: ["10.20", "12.16", "14.2", "lts", "current", "latest"]
+              node-version: ["10.20", "12.16", "14.2", "lts", "current"]


### PR DESCRIPTION
Use faster `node/default` executor instead of installing Node.js with `node/install` command.
https://circleci.com/orbs/registry/orb/circleci/node